### PR TITLE
rl-492/openapi-generator OpenapiGenerator:

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -15,11 +15,7 @@ Instead of using enums, generator produces static constants.
 
 To regenerate models from openapi definition, 
 clone [latest open api definitions](https://github.com/regulaforensics/DocumentReader-api-openapi)
-and set `DOCS_DEFINITION_FOLDER` as path to cloned directory.
-```bash
-export DOCS_DEFINITION_FOLDER="/home/user/projects/DocumentReader-api-openapi"
-```
-Then use next command from the project root.
+and use next command from the project root.
 ```bash
 ./update-models.sh
 ```

--- a/update-models.sh
+++ b/update-models.sh
@@ -1,31 +1,33 @@
 #!/bin/sh
 
-ENUM_MAPPINGS="TextFieldType=Integer,GraphicFieldType=Integer,Scenario=String,DocumentFormat=Integer,\
+DOCS_DEFINITION_FOLDER="${PWD}/../DocumentReader-web-openapi" \
+\
+&& ENUM_MAPPINGS="TextFieldType=Integer,GraphicFieldType=Integer,Scenario=String,DocumentFormat=Integer,\
 Light=Integer,Result=Integer,VerificationResult=Integer,RfidLocation=Integer,\
 DocumentTypeRecognitionResult=Integer,ProcessingStatus=Integer,Source=String,CheckResult=Integer,\
 LCID=Integer,DocumentType=Integer" \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "$DOCS_DEFINITION_FOLDER:/definitions" \
-openapitools/openapi-generator-cli generate \
+openapitools/openapi-generator-cli:v5.0.0-beta generate \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli generate \
+openapitools/openapi-generator-cli:v5.0.0-beta generate \
 -i /client/docs/openapi/index.yml -g java -o /client/clients/java/client \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 --import-mappings $ENUM_MAPPINGS \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli generate \
+openapitools/openapi-generator-cli:v5.0.0-beta generate \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 --import-mappings $ENUM_MAPPINGS,TextField=com.regula.documentreader.webclient.model.ext.TextField,\
 ImagesField=com.regula.documentreader.webclient.model.ext.ImagesField \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli generate \
+openapitools/openapi-generator-cli:v5.0.0-beta generate \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 --import-mappings $ENUM_MAPPINGS,Text=com.regula.documentreader.webclient.model.ext.Text,\

--- a/update-models.sh
+++ b/update-models.sh
@@ -8,26 +8,26 @@ DocumentTypeRecognitionResult=Integer,ProcessingStatus=Integer,Source=String,Che
 LCID=Integer,DocumentType=Integer" \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "$DOCS_DEFINITION_FOLDER:/definitions" \
-openapitools/openapi-generator-cli:v5.0.0-beta generate \
+openapitools/openapi-generator-cli:v5.0.0-beta2 generate \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli:v5.0.0-beta generate \
+openapitools/openapi-generator-cli:v5.0.0-beta2 generate \
 -i /client/docs/openapi/index.yml -g java -o /client/clients/java/client \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 --import-mappings $ENUM_MAPPINGS \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli:v5.0.0-beta generate \
+openapitools/openapi-generator-cli:v5.0.0-beta2 generate \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 --import-mappings $ENUM_MAPPINGS,TextField=com.regula.documentreader.webclient.model.ext.TextField,\
 ImagesField=com.regula.documentreader.webclient.model.ext.ImagesField \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli:v5.0.0-beta generate \
+openapitools/openapi-generator-cli:v5.0.0-beta2 generate \
 -i /definitions/index.yml -g java -o /client/client \
 -c /client/java-generator-config.json -t /client/client/generator-templates/ \
 --import-mappings $ENUM_MAPPINGS,Text=com.regula.documentreader.webclient.model.ext.Text,\


### PR DESCRIPTION
- add ability to run v5.0.0-beta openapi generator version
- add ability to run update-models.sh without DOCS_DEFINITION_FOLDER environment